### PR TITLE
JSHintのルールにJasmine宣言を追加

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,6 +18,7 @@
   "trailing": true,
   "smarttabs": true,
   "jquery": true,
+  "jasmine": true,
   "globals": {
     "angular": true
   }


### PR DESCRIPTION
JSHintが`describe`等のJasmineの関数に警告を出すのでルールを変更しました。

```
$ grunt jshint
Running "jshint:all" (jshint) task

test/spec/service/TodoStorageService.spec.js
  line 4   col 3   'describe' is not defined.
  line 6   col 5   'beforeEach' is not defined.
  line 9   col 5   'beforeEach' is not defined.
  line 9   col 16  'inject' is not defined.
  line 13  col 5   'describe' is not defined.
  line 14  col 7   'it' is not defined.
  line 16  col 9   'expect' is not defined.
  line 20  col 5   'describe' is not defined.
  line 21  col 7   'it' is not defined.
  line 24  col 9   'expect' is not defined.

✖ 10 problems
```
